### PR TITLE
update pyenv

### DIFF
--- a/bin/utils.sh
+++ b/bin/utils.sh
@@ -5,8 +5,9 @@ echoerr() {
 ensure_python_build_installed() {
   if [ ! -f "$(python_build_path)" ]; then
     download_python_build
+  else
+    git -C "$(pyenv_path)" pull > /dev/null || true
   fi
-  git -C "$(pyenv_path)" pull > /dev/null || true
 }
 
 download_python_build() {

--- a/bin/utils.sh
+++ b/bin/utils.sh
@@ -6,6 +6,7 @@ ensure_python_build_installed() {
   if [ ! -f "$(python_build_path)" ]; then
     download_python_build
   fi
+  git -C "$(pyenv_path)" pull > /dev/null || true
 }
 
 download_python_build() {


### PR DESCRIPTION
Looking at the erlang plugin, they do a version update on a list-all:
https://github.com/asdf-vm/asdf-erlang/blob/master/bin/list-all#L6
On the list-all, ensure_kerl_setup() gets called, which calls update_available_versions()

This PR hooks in the same way. On a call to list-all, the first thing is a call to ensure_python_build_installed() that checks pyenv is installed. If it's already installed, do a git pull instead.

I added an '|| true' so the command won't fail if the git pull fails for some reason.. I'm not sure how much that will be appreciated.

This requires git >= 1.8.5 from late 2013 for the -C, let me know if you'd prefer some cd'ing around instead.
https://github.com/git/git/blob/5fd09df3937f54c5cfda4f1087f5d99433cce527/Documentation/RelNotes/1.8.5.txt#L115-L116